### PR TITLE
Allowing external configuration

### DIFF
--- a/svg4everybody.ie8.js
+++ b/svg4everybody.ie8.js
@@ -53,8 +53,7 @@
 			if (settings.fix == 'replace') {
 				var
 				div = document.createElement('div'),
-				img = new Image(),
-				attributes = ['id', 'class', 'title'];
+				img = new Image();
 
 				img.src = use.getAttribute('xlink:href').replace('#', '.') + settings.replaceExt;
 


### PR DESCRIPTION
I re-worked the autotrigger branch to allow external configuration while keeping sane defaults.

``` javascript
var svg4eb = {
  fix = 'replace', //choose the fix type based on external testing etc
  replaceExt = '.svg', //allows replacing with inline svg when the browser supports inline svg as image
}
```

I'm not familiar with all the javascript shorthand you are using. Also I tend to opt for verbosity for readability. That being said, I tried to match your styling as much as I could.
