### PR TITLE
Added support for internal SVG references & non-alphanumeric fragment identifiers / IDs

### DIFF
--- a/svg4everybody.js
+++ b/svg4everybody.js
@@ -1,4 +1,12 @@
 (function (document, uses, requestAnimationFrame, CACHE, IE9TO11) {
+	function embed(svg, g) {
+		if (g) {
+			g = g.cloneNode(true);
+			g.removeAttribute('id');
+			svg.appendChild(g);
+		}
+	}
+	
 	function onload() {
 		var xhr = this, x = document.createElement('x'), s = xhr.s;
 
@@ -6,15 +14,7 @@
 
 		xhr.onload = function () {
 			s.splice(0).map(function (array) {
-				var g = x.querySelector('#' + array[1]);
-
-				if (g) {
-					g = g.cloneNode(true);
-
-					g.removeAttribute('id');
-
-					array[0].appendChild(g);
-				}
+				embed(array[0], x.querySelector('#' + array[1].replace(/(\W)/g, '\\$1')));
 			});
 		};
 
@@ -29,25 +29,31 @@
 			svg = use.parentNode,
 			url = use.getAttribute('xlink:href').split('#'),
 			url_root = url[0],
-			url_hash = url[1],
-			xhr = CACHE[url_root] = CACHE[url_root] || new XMLHttpRequest();
+			url_hash = url[1];
 
 			svg.removeChild(use);
-
-			if (!xhr.s) {
-				xhr.s = [];
-
-				xhr.open('GET', url_root);
-
-				xhr.onload = onload;
-
-				xhr.send();
-			}
-
-			xhr.s.push([svg, url_hash]);
-
-			if (xhr.readyState === 4) {
-				xhr.onload();
+			
+			if (url_root.length) {
+				var xhr = CACHE[url_root] = CACHE[url_root] || new XMLHttpRequest();
+	
+				if (!xhr.s) {
+					xhr.s = [];
+	
+					xhr.open('GET', url_root);
+	
+					xhr.onload = onload;
+	
+					xhr.send();
+				}
+	
+				xhr.s.push([svg, url_hash]);
+	
+				if (xhr.readyState === 4) {
+					xhr.onload();
+				}
+				
+			} else {
+				embed(svg, document.getElementById(url_hash));
 			}
 		}
 


### PR DESCRIPTION
Hi Jonathan,

I found (and patched) two issues:
1. The current usage of `x.querySelector()` will possibly fail when you have SVG fragment identifiers (IDs) containing non-alphanumeric characters (which is perfectly legal, e.g. `my~weird~id`). I implemented RegExp based escaping to enable these identifiers.
2. The script utterly failed with a "Syntax Error" when used inside a document that contains **internal SVG references** (e.g. in conjunction with an embedded inline SVG sprite):

``` html
<svg viewBox="0 0 48 48">
    <use xlink:href="#internal-id"></use>
</svg>
```

In these cases, the `url_root` is empty, which leads to an invalid XHR request. I implemented an alternative branch for internal references (using `getElementById()`) and created a common replacement method for both internal and external references (the `embed()` function).

I could test my modifications on Win 7 / IE 11 only, but I'm pretty sure they should work elsewhere as well. Also, the modifications would have to be applied to the IE6-8 and minified script versions, but I'd rather leave this up to you.

Cheers,
Joschi
