### PR TITLE
Improved a fallback PNG URL when xlink:href has query string

### DIFF
--- a/svg4everybody.ie8.js
+++ b/svg4everybody.ie8.js
@@ -37,10 +37,11 @@
 
 		while ((use = uses[0])) {
 			if (LTEIE8) {
-				var
-				img = new Image();
+				var img = new Image(), src, q;
 
-				img.src = use.getAttribute('xlink:href').replace('#', '.').replace(/^\./, '') + '.png';
+				src = use.getAttribute('xlink:href');
+				q = (/\?[^#]+/.exec(src) || [''])[0];
+				img.src = src.replace(/\?[^#]+/, '').replace('#', '.').replace(/^\./, '') + '.png' + q;
 
 				use.parentNode.replaceChild(img, use);
 			} else {


### PR DESCRIPTION
When the SVG has query string for cache control then it breaks the fallback PNG URL.

original url:

    spritemap.svg?12345#codepen

fallback url (current):

    spritemap.svg?12345.codepen.png

fallback url (this pull request):

    spritemap.svg.codepen.png?12345