### PR TITLE
package.json for submitting to npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"author" : "Jonathan Neal <https://github.com/jonathantneal>",
 	"contributors" : [],
 	"dependencies" : [],
+	"main": "svg4everybody.js",
 	"repository" : {"type": "git", "url": "git@github.com:jonathantneal/svg4everybody.git"},
 	"version" : "0.1.0"
 }


### PR DESCRIPTION
I was interested in using svg4everybody as a node dependency. Turns out I don't need it but thought it may be useful for other people who want external svg symbol/defs file. 

Let me know if this okay, then I'll go add it to npmjs.org
