### PR TITLE
Added sizing of PNG to match that of replaced SVG

### DIFF
--- a/svg4everybody.ie8.js
+++ b/svg4everybody.ie8.js
@@ -41,6 +41,21 @@
 				var
 				img = new Image();
 
+				// Sets size of PNG to match that of the replaced SVG
+				img.onload = function () {
+					var self = this,
+						parentNode = self.parentNode;
+
+					setTimeout(function () {
+						if ( parentNode.getAttribute('width') ) {
+							self.setAttribute('width', parentNode.getAttribute('width'));
+						}
+						if ( parentNode.getAttribute('height') ) {
+							self.setAttribute('height', parentNode.getAttribute('height'));
+						}
+					}, 10);
+				}
+
 				img.src = use.getAttribute('xlink:href').replace('#', '.').replace(/^\./, '') + '.png';
 
 				use.parentNode.replaceChild(img, use);


### PR DESCRIPTION
Hi,

I have adjusted the PNG replacement bit for IE8 so that it sets the correct width and height attributes which may have been set on the SVG element so the PNG will be of the same size as the SVG intended to be.