### PR TITLE
Fix IE 11 in Windows 10 TP

### DIFF
--- a/svg4everybody.ie8.js
+++ b/svg4everybody.ie8.js
@@ -90,7 +90,7 @@
 	window.requestAnimationFrame || window.setTimeout,
 	{},
 	/MSIE\s[1-8]\b/.test(navigator.userAgent),
-	/Trident\/[567]\b/.test(navigator.userAgent) || (navigator.userAgent.match(/AppleWebKit\/(\d+)/) || [])[1] < 537,
+	/Trident\/[567]\b/.test(navigator.userAgent) || /Edge\/12\.\d+/.test(navigator.userAgent) || (navigator.userAgent.match(/AppleWebKit\/(\d+)/) || [])[1] < 537,
 	document.createElement('svg'),
 	document.createElement('use')
 );

--- a/svg4everybody.js
+++ b/svg4everybody.js
@@ -80,5 +80,5 @@
 	document.getElementsByTagName('use'),
 	window.requestAnimationFrame || window.setTimeout,
 	{},
-	/Trident\/[567]\b/.test(navigator.userAgent) || (navigator.userAgent.match(/AppleWebKit\/(\d+)/) || [])[1] < 537
+	/Trident\/[567]\b/.test(navigator.userAgent) || /Edge\/12\.\d+/.test(navigator.userAgent) || (navigator.userAgent.match(/AppleWebKit\/(\d+)/) || [])[1] < 537
 );


### PR DESCRIPTION
The user agent check you pass into the closure isn't catching the latest "IE11" on Win 10 TP.  I've copied the UA string from that browser below:

"Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0"

The PR adds an extra check that passes the new IE11. This is definitely a short-term fix as we can't be sure what the UA's will be on the TWO MS browsers in the final Win 10.  Any thoughts on abandoning UA checking for feature detection?

Also, just FYI, I only added the check to the non-minified versions.