### PR TITLE
Added option to Grunt's task Uglify to remove legacy IE8 code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,13 @@ module.exports = function (grunt) {
 			]
 		},
 		uglify: {
+			options: {
+				compress: {
+					global_defs: {
+						"LEGACY_SUPPORT": grunt.option('legacy') !== undefined ? grunt.option('legacy') : true
+					}
+				}
+			},
 			build: {
 				files: [
 					{

--- a/lib/svg4everybody.js
+++ b/lib/svg4everybody.js
@@ -1,10 +1,12 @@
 /*! svg4everybody v1.0.0 | github.com/jonathantneal/svg4everybody */
 
 var CACHE = {};
-var NOSVG = /MSIE\s[1-8]\b/.test(navigator.userAgent);
+if (LEGACY_SUPPORT) {
+	var NOSVG = /MSIE\s[1-8]\b/.test(navigator.userAgent);
+}
 var NOEXT = NOSVG || (navigator.userAgent.match(/AppleWebKit\/(\d+)|Edge\/12\b|Trident\/[567]\b/) || [])[1] < 538;
 
-if (NOSVG) {
+if (LEGACY_SUPPORT && NOSVG) {
 	document.createElement('svg');
 	document.createElement('use');
 }
@@ -49,7 +51,7 @@ function svg4everybody() {
 	var use;
 
 	while (use = uses[0]) {
-		if (NOSVG) {
+		if (LEGACY_SUPPORT && NOSVG) {
 			var img = new Image(), src, q;
 
 			src = use.getAttribute('xlink:href');


### PR DESCRIPTION
For folks who are dropping IE8 support, now that Edge is out, added a global def that Uglify will use with its `dead_code` option to remove unnecessary bits of code.

`$ grunt build --legacy=false # removes NOSVG (PNG) support.`