### PR TITLE
Regex to test for properly-formed asset URL

### DIFF
--- a/svg4everybody.js
+++ b/svg4everybody.js
@@ -33,10 +33,21 @@
 		xhr.onload();
 	}
 
-	function onframe() {
-		var use;
+	// NOTE (TS): added regex to test for presence of properly-formed 
+	// asset url; prevents issue of uncompiled icon directive being 
+	// processed by this library, until Angular has finished parsing/compiling
+	var urlRegex = /\.*\.svg/;
 
-		while ((use = uses[0])) {
+	function onframe() {
+		var use,
+			urlIsSet = false;
+		if(uses[0]) {
+			// if there's something to potentially process, make sure Angular 
+			// has compiled the markup into something useable before continuing
+			urlIsSet = urlRegex.test(uses[0].getAttribute('xlink:href'));
+		}
+		while ( (use = uses[0] ) && urlIsSet ) {
+
 			var
 			svg = use.parentNode,
 			url = use.getAttribute('xlink:href').split('#'),
@@ -68,7 +79,6 @@
 				embed(svg, document.getElementById(url_hash));
 			}
 		}
-
 		requestAnimationFrame(onframe);
 	}
 


### PR DESCRIPTION
Inspect the xlink:href attr to ensure that it ends in '.svg', which
prevents parsed template-based use cases from failing. See
https://github.com/jonathantneal/svg4everybody/issues/53 for more

Have not applied this to the 'legacy' file. Can probably be added there, but I haven't tested since our project didn't require IE8 support.

This solution works by checking that the value of 'uses[0].getAttribute('xlink:href')' on line 47 (of this commit) is a string ending in '.svg'. This prevented a problem we had in Angular, where directive markup like '&lt;use xlink:href="{{ getUrl() }}">&lt;/use>', wouldn't be fully parsed/interpolated by the time svg4everybody ran, resulting in a value for 'uses[0].getAttribute('xlink:href')' of {{getUrl}}.

As noted in the other post, this was intermittent, and only occurred in certain device/browser combos. Adding this sanity check doesn't seem to have much of a downside, so thought it worth offering up.