### PR TITLE
Use non-minified non-legacy version as main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"grunt-umd": "^2.3.3",
 		"load-grunt-tasks": "^3.2.0"
 	},
-	"main": "dist/svg4everybody.legacy.min.js",
+	"main": "dist/svg4everybody.js",
 	"scripts": {
 		"build": "grunt build",
 		"clean": "git checkout dist/svg4everybody.js && git checkout dist/svg4everybody.min.js && git checkout dist/svg4everybody.legacy.js && git checkout dist/svg4everybody.legacy.min.js",


### PR DESCRIPTION
The legacy version should only be used if legacy support is necessary.
The main field is used by node/browserify/webpack users, which also likely have a minifier in their pipeline. Having a minified file as default makes debugging difficult.