### PR TITLE
adding cache for elements

### DIFF
--- a/dist/svg4everybody.js
+++ b/dist/svg4everybody.js
@@ -13,14 +13,17 @@
             svg.appendChild(fragment);
         }
     }
+    function createSvgElement(xhr) {
+        var xElement;
+        "undefined" == typeof xhr._elementCache && (xhr._elementCache = {}), "undefined" == typeof xhr._elementCache[xhr.responseURL] ? (xElement = document.createElement("x"), 
+        xElement.innerHTML = xhr.responseText, xhr._elementCache[xhr.responseURL] = xElement) : xElement = xhr._elementCache[xhr.responseURL], 
+        xhr.s.splice(0).map(function(array) {
+            embed(array[0], xElement.querySelector("#" + array[1].replace(/(\W)/g, "\\$1")));
+        });
+    }
     function loadreadystatechange(xhr) {
         xhr.onreadystatechange = function() {
-            if (4 === xhr.readyState) {
-                var x = document.createElement("x");
-                x.innerHTML = xhr.responseText, xhr.s.splice(0).map(function(array) {
-                    embed(array[0], x.querySelector("#" + array[1].replace(/(\W)/g, "\\$1")));
-                });
-            }
+            4 === xhr.readyState && createSvgElement(xhr);
         }, xhr.onreadystatechange();
     }
     function svg4everybody(opts) {

--- a/dist/svg4everybody.legacy.js
+++ b/dist/svg4everybody.legacy.js
@@ -13,14 +13,17 @@
             svg.appendChild(fragment);
         }
     }
+    function createSvgElement(xhr) {
+        var xElement;
+        "undefined" == typeof xhr._elementCache && (xhr._elementCache = {}), "undefined" == typeof xhr._elementCache[xhr.responseURL] ? (xElement = document.createElement("x"), 
+        xElement.innerHTML = xhr.responseText, xhr._elementCache[xhr.responseURL] = xElement) : xElement = xhr._elementCache[xhr.responseURL], 
+        xhr.s.splice(0).map(function(array) {
+            embed(array[0], xElement.querySelector("#" + array[1].replace(/(\W)/g, "\\$1")));
+        });
+    }
     function loadreadystatechange(xhr) {
         xhr.onreadystatechange = function() {
-            if (4 === xhr.readyState) {
-                var x = document.createElement("x");
-                x.innerHTML = xhr.responseText, xhr.s.splice(0).map(function(array) {
-                    embed(array[0], x.querySelector("#" + array[1].replace(/(\W)/g, "\\$1")));
-                });
-            }
+            4 === xhr.readyState && createSvgElement(xhr);
         }, xhr.onreadystatechange();
     }
     function svg4everybody(opts) {

--- a/lib/svg4everybody.js
+++ b/lib/svg4everybody.js
@@ -18,16 +18,30 @@ function embed(svg, g) {
 	}
 }
 
+function createSvgElement(xhr) {
+	var xElement;
+
+	if (typeof xhr._elementCache === 'undefined') {
+		xhr._elementCache = {};
+	}
+
+	if (typeof xhr._elementCache[xhr.responseURL] === 'undefined') {
+		xElement = document.createElement('x');
+		xElement.innerHTML = xhr.responseText;
+		xhr._elementCache[xhr.responseURL] = xElement;
+	} else {
+		xElement = xhr._elementCache[xhr.responseURL];
+	}
+
+	xhr.s.splice(0).map(function (array) {
+		embed(array[0], xElement.querySelector('#' + array[1].replace(/(\W)/g, '\\$1')));
+	});
+}
+
 function loadreadystatechange(xhr) {
 	xhr.onreadystatechange = function () {
 		if (xhr.readyState === 4) {
-			var x = document.createElement('x');
-
-			x.innerHTML = xhr.responseText;
-
-			xhr.s.splice(0).map(function (array) {
-				embed(array[0], x.querySelector('#' + array[1].replace(/(\W)/g, '\\$1')));
-			});
+			createSvgElement(xhr);
 		}
 	};
 


### PR DESCRIPTION
Adding cache for `X` element.

Prolifer results:
![image](https://cloud.githubusercontent.com/assets/1244112/10607142/32910084-7740-11e5-87ff-9222360bc91e.png)

vs

![image](https://cloud.githubusercontent.com/assets/1244112/10607146/37641560-7740-11e5-8ace-5cc182f7f4f1.png)
