### PR TITLE
Bugfix? requestAnimationFrame being called forever

### DIFF
--- a/lib/svg4everybody.js
+++ b/lib/svg4everybody.js
@@ -116,9 +116,8 @@ function svg4everybody(opts) {
 					}
 				}
 			}
+  		requestAnimationFrame(oninterval, 17);
 		}
-
-		requestAnimationFrame(oninterval, 17);
 	}
 
 	if (polyfill) {


### PR DESCRIPTION
Maybe a fix?

It seems that requestAnimationFrame is called forever because it's inside the oninterval() callback. But by moving it into the while() loop the requestAnimationFrame() will only called back if there are still use tags to replace.