### PR TITLE
Allow <use> not at root of svg

### DIFF
--- a/lib/svg4everybody.js
+++ b/lib/svg4everybody.js
@@ -1,10 +1,16 @@
 /*! svg4everybody v2.0.3 | github.com/jonathantneal/svg4everybody */
 
-function embed(svg, target) {
+function embed(destination, target) {
 	// if the target exists
 	if (target) {
 		// create a document fragment to hold the contents of the target
 		var fragment = document.createDocumentFragment();
+
+		// Find the svg that contains us
+		var svg = destination;
+		while (svg && !/svg/i.test(svg.nodeName)) {
+			svg = svg.parentNode;
+		}
 
 		// cache the closest matching viewBox
 		var viewBox = !svg.getAttribute('viewBox') && target.getAttribute('viewBox');
@@ -23,7 +29,7 @@ function embed(svg, target) {
 		}
 
 		// append the fragment into the svg
-		svg.appendChild(fragment);
+		destination.appendChild(fragment);
 	}
 }
 
@@ -124,8 +130,8 @@ function svg4everybody(rawopts) {
 			// get the current <svg>
 			var svg = use.parentNode;
 
-			if (svg && /svg/i.test(svg.nodeName)) {
-				var src = use.getAttribute('xlink:href');
+			if (svg) {
+				var src = use.getAttribute('xlink:href') || use.getAttributeNS('http://www.w3.org/1999/xlink', 'href');
 
 				// if running with legacy support
 				if (LEGACY_SUPPORT && nosvg) {

--- a/test/index.html
+++ b/test/index.html
@@ -18,7 +18,7 @@ if (location.hash !== '#nofill') {
 }
 
 function addSVG(node, href) {
-	node.innerHTML ='<' + 'svg role="presentation"' + '><' + 'use xlink:href="' + href + '"/' + '><' + '/svg' + '>';
+	node.innerHTML = '<' + 'svg role="presentation"' + '><' + 'use xlink:href="' + href + '"/' + '><' + '/svg' + '>';
 	node.parentNode.replaceChild(node.lastChild, node);
 }
 </script>
@@ -42,7 +42,9 @@ svg {
 	</svg>
 
 	<svg title="Camera" role="img">
-		<use xlink:href="demo.svg#camera"/>
+		<g>
+			<use xlink:href="demo.svg#camera"/>
+		</g>
 	</svg>
 
 	<span>


### PR DESCRIPTION
* Change the test to put the camera demo inside a `<g>`.
* Use `getAttributeNS` if `getAttribute` doesn't work.
* Don't check that the use' parent element is an svg
* Loop up through the DOM looking for an svg if the use' parent element isn't one.

Here is the new test page on IEs 6 - 11:
![screen shot 2016-03-02 at 11 34 18](https://cloud.githubusercontent.com/assets/108641/13459340/bdfc541e-e06a-11e5-91b4-0c4fa1c5ca14.png)
