### PR TITLE
Preserve preserveAspectRatio in addition to viewBox

### DIFF
--- a/dist/svg4everybody.js
+++ b/dist/svg4everybody.js
@@ -9,9 +9,9 @@
         // if the target exists
         if (target) {
             // create a document fragment to hold the contents of the target
-            var fragment = document.createDocumentFragment(), viewBox = !svg.getAttribute("viewBox") && target.getAttribute("viewBox");
-            // conditionally set the viewBox on the svg
-            viewBox && svg.setAttribute("viewBox", viewBox);
+            var fragment = document.createDocumentFragment(), viewBox = !svg.getAttribute("viewBox") && target.getAttribute("viewBox"), preserveAspectRatio = !svg.getAttribute("preserveAspectRatio") && target.getAttribute("preserveAspectRatio");
+            // conditionally set the attributes on the svg
+            viewBox && svg.setAttribute("viewBox", viewBox), preserveAspectRatio && svg.setAttribute("preserveAspectRatio", preserveAspectRatio);
             // copy the contents of the clone into the fragment
             for (// clone the target
             var clone = target.cloneNode(!0); clone.childNodes.length; ) {

--- a/dist/svg4everybody.legacy.js
+++ b/dist/svg4everybody.legacy.js
@@ -9,9 +9,9 @@
         // if the target exists
         if (target) {
             // create a document fragment to hold the contents of the target
-            var fragment = document.createDocumentFragment(), viewBox = !svg.getAttribute("viewBox") && target.getAttribute("viewBox");
-            // conditionally set the viewBox on the svg
-            viewBox && svg.setAttribute("viewBox", viewBox);
+            var fragment = document.createDocumentFragment(), viewBox = !svg.getAttribute("viewBox") && target.getAttribute("viewBox"), preserveAspectRatio = !svg.getAttribute("preserveAspectRatio") && target.getAttribute("preserveAspectRatio");
+            // conditionally set the attributes on the svg
+            viewBox && svg.setAttribute("viewBox", viewBox), preserveAspectRatio && svg.setAttribute("preserveAspectRatio", preserveAspectRatio);
             // copy the contents of the clone into the fragment
             for (// clone the target
             var clone = target.cloneNode(!0); clone.childNodes.length; ) {

--- a/dist/svg4everybody.legacy.min.js
+++ b/dist/svg4everybody.legacy.min.js
@@ -4,12 +4,12 @@ function a(a,b){
 // if the target exists
 if(b){
 // create a document fragment to hold the contents of the target
-var c=document.createDocumentFragment(),d=!a.getAttribute("viewBox")&&b.getAttribute("viewBox");
-// conditionally set the viewBox on the svg
-d&&a.setAttribute("viewBox",d);
+var c=document.createDocumentFragment(),d=!a.getAttribute("viewBox")&&b.getAttribute("viewBox"),e=!a.getAttribute("preserveAspectRatio")&&b.getAttribute("preserveAspectRatio");
+// conditionally set the attributes on the svg
+d&&a.setAttribute("viewBox",d),e&&a.setAttribute("preserveAspectRatio",e);
 // copy the contents of the clone into the fragment
 for(// clone the target
-var e=b.cloneNode(!0);e.childNodes.length;)c.appendChild(e.firstChild);
+var f=b.cloneNode(!0);f.childNodes.length;)c.appendChild(f.firstChild);
 // append the fragment into the svg
 a.appendChild(c)}}function b(b){
 // listen to changes in the request

--- a/dist/svg4everybody.min.js
+++ b/dist/svg4everybody.min.js
@@ -5,13 +5,13 @@ function a(a,b){
 // if the target exists
 if(b){
 // create a document fragment to hold the contents of the target
-var c=document.createDocumentFragment(),d=!a.getAttribute("viewBox")&&b.getAttribute("viewBox");
-// conditionally set the viewBox on the svg
-d&&a.setAttribute("viewBox",d);
+var c=document.createDocumentFragment(),d=!a.getAttribute("viewBox")&&b.getAttribute("viewBox"),e=!a.getAttribute("preserveAspectRatio")&&b.getAttribute("preserveAspectRatio");
+// conditionally set the attributes on the svg
+d&&a.setAttribute("viewBox",d),e&&a.setAttribute("preserveAspectRatio",e);
 // copy the contents of the clone into the fragment
 for(
 // clone the target
-var e=b.cloneNode(!0);e.childNodes.length;)c.appendChild(e.firstChild);
+var f=b.cloneNode(!0);f.childNodes.length;)c.appendChild(f.firstChild);
 // append the fragment into the svg
 a.appendChild(c)}}function b(b){
 // listen to changes in the request

--- a/lib/svg4everybody.js
+++ b/lib/svg4everybody.js
@@ -6,12 +6,16 @@ function embed(svg, target) {
 		// create a document fragment to hold the contents of the target
 		var fragment = document.createDocumentFragment();
 
-		// cache the closest matching viewBox
+		// cache the closest matching attributes
 		var viewBox = !svg.getAttribute('viewBox') && target.getAttribute('viewBox');
+		var preserveAspectRatio = !svg.getAttribute('preserveAspectRatio') && target.getAttribute('preserveAspectRatio');
 
-		// conditionally set the viewBox on the svg
+		// conditionally set the attributes on the svg
 		if (viewBox) {
 			svg.setAttribute('viewBox', viewBox);
+		}
+		if (preserveAspectRatio) {
+			svg.setAttribute('preserveAspectRatio', preserveAspectRatio);
 		}
 
 		// clone the target


### PR DESCRIPTION
When embedding a cloned SVG, maintain `preserveAspectRatio` as well as `viewBox` from the symbol