### PR TITLE
Using importNode instead cloneNode.

### DIFF
--- a/dist/svg4everybody.js
+++ b/dist/svg4everybody.js
@@ -14,7 +14,7 @@
             viewBox && svg.setAttribute("viewBox", viewBox);
             // copy the contents of the clone into the fragment
             for (// clone the target
-            var clone = target.cloneNode(!0); clone.childNodes.length; ) {
+            var clone = document.importNode ? document.importNode(target, !0) : target.cloneNode(!0); clone.childNodes.length; ) {
                 fragment.appendChild(clone.firstChild);
             }
             // append the fragment into the svg

--- a/dist/svg4everybody.legacy.js
+++ b/dist/svg4everybody.legacy.js
@@ -14,7 +14,7 @@
             viewBox && svg.setAttribute("viewBox", viewBox);
             // copy the contents of the clone into the fragment
             for (// clone the target
-            var clone = target.cloneNode(!0); clone.childNodes.length; ) {
+            var clone = document.importNode ? document.importNode(target, !0) : target.cloneNode(!0); clone.childNodes.length; ) {
                 fragment.appendChild(clone.firstChild);
             }
             // append the fragment into the svg

--- a/dist/svg4everybody.legacy.min.js
+++ b/dist/svg4everybody.legacy.min.js
@@ -9,7 +9,7 @@ var c=document.createDocumentFragment(),d=!a.getAttribute("viewBox")&&b.getAttri
 d&&a.setAttribute("viewBox",d);
 // copy the contents of the clone into the fragment
 for(// clone the target
-var e=b.cloneNode(!0);e.childNodes.length;)c.appendChild(e.firstChild);
+var e=document.importNode?document.importNode(b,!0):b.cloneNode(!0);e.childNodes.length;)c.appendChild(e.firstChild);
 // append the fragment into the svg
 a.appendChild(c)}}function b(b){
 // listen to changes in the request

--- a/dist/svg4everybody.min.js
+++ b/dist/svg4everybody.min.js
@@ -11,7 +11,7 @@ d&&a.setAttribute("viewBox",d);
 // copy the contents of the clone into the fragment
 for(
 // clone the target
-var e=b.cloneNode(!0);e.childNodes.length;)c.appendChild(e.firstChild);
+var e=document.importNode?document.importNode(b,!0):b.cloneNode(!0);e.childNodes.length;)c.appendChild(e.firstChild);
 // append the fragment into the svg
 a.appendChild(c)}}function b(b){
 // listen to changes in the request

--- a/lib/svg4everybody.js
+++ b/lib/svg4everybody.js
@@ -15,7 +15,7 @@ function embed(svg, target) {
 		}
 
 		// clone the target
-		var clone = target.cloneNode(true);
+		var clone = document.importNode ? document.importNode(target, true) : target.cloneNode(true);
 
 		// copy the contents of the clone into the fragment
 		while (clone.childNodes.length) {


### PR DESCRIPTION
For historical reasons our team rewrites document.domain property to parent domain on our legacy code. I mean from _subdoamin.domain.com_ to _domain.com_.
In this case [Node.cloneNode()](https://developer.mozilla.org/ru/docs/Web/API/Node/cloneNode) thorows error **SCRIPT5022: WrongDocumentError** on IE.
So I think that [Document.importNode](https://developer.mozilla.org/en-US/docs/Web/API/Document/importNode) is better solution
