### PR TITLE
fix bug issue property 'split': object is null or undefined on IE9 (#78) with support for ie8

### DIFF
--- a/lib/svg4everybody.js
+++ b/lib/svg4everybody.js
@@ -125,9 +125,8 @@ function svg4everybody(rawopts) {
 			var svg = use.parentNode;
 
 			if (svg && /svg/i.test(svg.nodeName)) {
-				/*jshint sub:true*/
 				// this notation is to be used whn ie8 parsing is failing because of getAttributeNS
-				var src = use.getAttribute('xlink:href') || use['getAttributeNS']('http://www.w3.org/1999/xlink', 'href');
+				var src = use.getAttribute('xlink:href') || use['getAttributeNS']('http://www.w3.org/1999/xlink', 'href');// jshint ignore:line
 
 				// if running with legacy support
 				if (LEGACY_SUPPORT && nosvg) {

--- a/lib/svg4everybody.js
+++ b/lib/svg4everybody.js
@@ -125,7 +125,7 @@ function svg4everybody(rawopts) {
 			var svg = use.parentNode;
 
 			if (svg && /svg/i.test(svg.nodeName)) {
-				var src = use.getAttribute('xlink:href');
+				var src = use.getAttribute('xlink:href') || use['getAttributeNS']('http://www.w3.org/1999/xlink', 'href');
 
 				// if running with legacy support
 				if (LEGACY_SUPPORT && nosvg) {

--- a/lib/svg4everybody.js
+++ b/lib/svg4everybody.js
@@ -125,6 +125,8 @@ function svg4everybody(rawopts) {
 			var svg = use.parentNode;
 
 			if (svg && /svg/i.test(svg.nodeName)) {
+				/*jshint sub:true*/
+				// this notation is to be used whn ie8 parsing is failing because of getAttributeNS
 				var src = use.getAttribute('xlink:href') || use['getAttributeNS']('http://www.w3.org/1999/xlink', 'href');
 
 				// if running with legacy support


### PR DESCRIPTION
I believe this to be a better solution than #79 to the issue we are having
Tested on ie8, ie9, ie11 and edge, plus the usual suspects
Chrome  54.0.2840.71 (64bits)
Firefox 48.0.2