### PR TITLE
Fix issue appending svg element in IE 11 (fixes #159)

### DIFF
--- a/lib/svg4everybody.js
+++ b/lib/svg4everybody.js
@@ -40,6 +40,10 @@ function loadreadystatechange(xhr) {
 				cachedDocument = xhr._cachedDocument = document.implementation.createHTMLDocument('');
 
 				cachedDocument.body.innerHTML = xhr.responseText;
+				
+				// ensure domains are the same, otherwise we'll have issues appending the
+				// element in IE 11
+				cachedDocument.domain = document.domain
 
 				xhr._cachedTarget = {};
 			}

--- a/lib/svg4everybody.js
+++ b/lib/svg4everybody.js
@@ -43,7 +43,7 @@ function loadreadystatechange(xhr) {
 				
 				// ensure domains are the same, otherwise we'll have issues appending the
 				// element in IE 11
-				cachedDocument.domain = document.domain
+				cachedDocument.domain = document.domain;
 
 				xhr._cachedTarget = {};
 			}

--- a/lib/svg4everybody.js
+++ b/lib/svg4everybody.js
@@ -40,7 +40,7 @@ function loadreadystatechange(xhr) {
 				cachedDocument = xhr._cachedDocument = document.implementation.createHTMLDocument('');
 
 				cachedDocument.body.innerHTML = xhr.responseText;
-				
+
 				// ensure domains are the same, otherwise we'll have issues appending the
 				// element in IE 11
 				cachedDocument.domain = document.domain;


### PR DESCRIPTION
Fix issue appending svg element in IE 11 when document.domain is manually set in javascript, and differs from the full domain in the url.
Fixes #159